### PR TITLE
change expiration equality check

### DIFF
--- a/mac-exercises/src/main/scala/moe/jmcardon/JWTAuth.scala
+++ b/mac-exercises/src/main/scala/moe/jmcardon/JWTAuth.scala
@@ -35,7 +35,7 @@ object JWTAuth {
       expiration <- IO(Instant.now.plusSeconds(20))
       subset = SubsetJWT(JWTClaims(expiration = Some(expiration)))
       parsed <- subset.check(k)
-    } yield parsed.body.expiration.exists(_.equals(expiration))
+    } yield parsed.body.expiration.exists(e => e.equals(expiration) || e.isBefore(expiration))
 
     println(s"Result: ${program.unsafeRunSync()}")
   }


### PR DESCRIPTION
`expiration` is clearly after the one in the JWT since we verify that the JWT hasn't yet expired